### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -283,7 +283,7 @@ function showFallacyTooltip(element: HTMLElement, fallacy: FallacyMatch): void {
       ${fallacy.fallacyName}
     </div>
     <div style="margin-bottom: 8px; color: #333;">
-      ${fallacy.description}
+      ${escapeHTML(fallacy.description)}
     </div>
     <div style="font-size: 12px; color: #666;">
       Confidence: ${Math.round(fallacy.confidence * 100)}%
@@ -321,6 +321,20 @@ function showFallacyTooltip(element: HTMLElement, fallacy: FallacyMatch): void {
   setTimeout(() => document.addEventListener('click', removeTooltip), 100);
 }
 
+// Escapes a string for HTML - replaces &, <, >, ", ' with their safe equivalents
+function escapeHTML(str: string): string {
+  return str.replace(/[&<>"']/g, function (match) {
+    switch (match) {
+      case '&': return '&amp;';
+      case '<': return '&lt;';
+      case '>': return '&gt;';
+      case '"': return '&quot;';
+      case "'": return '&#39;';
+      default: return match;
+    }
+  });
+}
+
 function showFallacyExplanation(fallacy: FallacyMatch): void {
   const modal = document.createElement('div');
   modal.className = 'mle-fallacy-modal';
@@ -349,10 +363,10 @@ function showFallacyExplanation(fallacy: FallacyMatch): void {
   `;
 
   content.innerHTML = `
-    <h3 style="margin-top: 0; color: #d63384;">${fallacy.fallacyName}</h3>
-    <p><strong>Description:</strong> ${fallacy.description}</p>
-    <p><strong>Explanation:</strong> ${fallacy.explanation}</p>
-    <p><strong>Detected text:</strong> "${fallacy.matchedText}"</p>
+    <h3 style="margin-top: 0; color: #d63384;">${escapeHTML(fallacy.fallacyName)}</h3>
+    <p><strong>Description:</strong> ${escapeHTML(fallacy.description)}</p>
+    <p><strong>Explanation:</strong> ${escapeHTML(fallacy.explanation)}</p>
+    <p><strong>Detected text:</strong> "${escapeHTML(fallacy.matchedText)}"</p>
     <p><strong>Confidence:</strong> ${Math.round(fallacy.confidence * 100)}%</p>
     <button style="
       background: #007bff;


### PR DESCRIPTION
Potential fix for [https://github.com/yupitsleen/media-literacy-extension/security/code-scanning/3](https://github.com/yupitsleen/media-literacy-extension/security/code-scanning/3)

To fix the vulnerability, all data interpolated into `content.innerHTML` must be contextually escaped before insertion, ensuring that meta-characters (like `<`, `>`, `&`, `"`) in the extracted and analyzed text cannot be interpreted as HTML/JS by the browser. The best way is to escape each interpolated variable prior to building the HTML string—using a robust HTML escaping function. Changes should be made at every location that DOM-extracted or user-controlled text flows into HTML (especially in modals/tooltips).

Specifically, in `src/content/content-script.ts`, within the function `showFallacyExplanation`, before interpolating `fallacy.fallacyName`, `fallacy.description`, `fallacy.explanation`, and `fallacy.matchedText`, each string should pass through a simple escaping routine. An inline utility function (e.g., `escapeHTML`) should be provided in the file, to perform replacements for HTML meta characters with their corresponding entities.

Similarly, the same pattern should be applied to any other uses of innerHTML that interpolate DOM-extracted or user-generated values, such as in tooltips (e.g., `showFallacyTooltip`). Every possibly unsafe variable must be escaped before use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
