### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI/CD Pipeline
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yupitsleen/media-literacy-extension/security/code-scanning/2](https://github.com/yupitsleen/media-literacy-extension/security/code-scanning/2)

To fix the problem, you should add an explicit `permissions` block to the workflow YAML file. This should be placed at the root level to cover all jobs, unless you wish to specify the block per-job instead. Since none of the steps require write access to repository contents, issues, or pull requests, you should assign only the minimum required permissions: `contents: read`. This will ensure that GITHUB_TOKEN can only read repository contents, minimizing the risk surface. You need to insert the following under the workflow `name` or before `on:` at the top of the file:  
```yaml
permissions:
  contents: read
```
No new imports or dependencies are required. Only a top-level YAML block needs insertion.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
